### PR TITLE
Only round the bottom corners for items that are completely empty

### DIFF
--- a/src/Generator/Generators/HtmlOmdGenerator.cs
+++ b/src/Generator/Generators/HtmlOmdGenerator.cs
@@ -104,13 +104,6 @@ namespace Generator.Generators
                 memberBuilder.AppendLine("</ul>");
             }
 
-             
-
-
-
-
-
-
             sw.WriteLine($"<div class='{kind}HeaderBox{(isEmpty ? " noMembers" : "")}'>");
 
             //Write class name + Inheritance

--- a/src/Generator/Generators/HtmlOmdGenerator.cs
+++ b/src/Generator/Generators/HtmlOmdGenerator.cs
@@ -44,7 +44,74 @@ namespace Generator.Generators
                 sw.WriteLine($"<div class='namespaceHeader' id='{nsname}'>{nsname}</div>");
             }
             sw.WriteLine($"<div class='objectBox' id='{type.GetFullTypeName()}'>");
-            sw.WriteLine($"<div class='{kind}HeaderBox'>");
+            bool isEmpty = true;
+
+            var memberBuilder = new StringBuilder();
+            //List out members
+            if (type.GetConstructors().Any())
+            {
+                isEmpty = false;
+                memberBuilder.AppendLine($"<span class='memberGroup'>Constructors</span><ul>");
+                foreach (var method in type.GetConstructors())
+                {
+                    var str = FormatMember(method);
+                    memberBuilder.AppendLine($"{GetIcon(method, str)}");
+                }
+                memberBuilder.AppendLine("</ul>");
+            }
+            if (type.GetProperties().Any())
+            {
+                isEmpty = false;
+                memberBuilder.AppendLine($"<span class='memberGroup'>Properties</span><ul>");
+                foreach (var method in type.GetProperties())
+                {
+                    var str = FormatMember(method);
+                    memberBuilder.AppendLine($"{GetIcon(method, str)}");
+                }
+                memberBuilder.AppendLine("</ul>");
+            }
+            if (type.GetMethods().Any())
+            {
+                isEmpty = false;
+                memberBuilder.AppendLine($"<span class='memberGroup'>Methods</span><ul>");
+                foreach (var method in type.GetMethods())
+                {
+                    var str = FormatMember(method);
+                    memberBuilder.AppendLine($"{GetIcon(method, str)}");
+                }
+                memberBuilder.AppendLine("</ul>");
+            }
+            if (type.GetEvents().Any())
+            {
+                isEmpty = false;
+                memberBuilder.AppendLine($"<span class='memberGroup'>Events</span><ul>");
+                foreach (var method in type.GetEvents())
+                {
+                    var str = FormatMember(method);
+                    memberBuilder.AppendLine($"{GetIcon(method, str)}");
+                }
+                memberBuilder.AppendLine("</ul>");
+            }
+            if (type.TypeKind == TypeKind.Enum)
+            {
+                isEmpty = false;
+                memberBuilder.AppendLine("<ul>");
+                foreach (var e in type.GetEnums())
+                {
+                    string str = Briefify(e);
+                    memberBuilder.AppendLine($"{GetIcon(e, str)}");
+                }
+                memberBuilder.AppendLine("</ul>");
+            }
+
+             
+
+
+
+
+
+
+            sw.WriteLine($"<div class='{kind}HeaderBox{(isEmpty ? " noMembers" : "")}'>");
 
             //Write class name + Inheritance
             var brief = type.GetDescription();
@@ -57,66 +124,22 @@ namespace Generator.Generators
                 sw.Write(" : " + FormatType(type.BaseType));
             }
             sw.WriteLine("</span>");
-            
             //Document interfaces
             if (type.GetInterfaces().Any())
-            {                
+            {
+                isEmpty = false;
                 sw.Write("<br/>Implements " + string.Join(", ", type.GetInterfaces().Select(i => FormatType(i))) + "</span>");
             }
             sw.WriteLine("</div>"); //End header box
-            //List out members
-            if (type.GetConstructors().Any())
-            {
-                sw.WriteLine($"<span class='memberGroup'>Constructors</span><ul>");
-                foreach (var method in type.GetConstructors())
-                {
-                    var str = FormatMember(method);
-                    sw.WriteLine($"{GetIcon(method, str)}");
-                }
-                sw.WriteLine("</ul>");
-            }
-            if (type.GetProperties().Any())
-            {
-                sw.WriteLine($"<span class='memberGroup'>Properties</span><ul>");
-                foreach (var method in type.GetProperties())
-                {
-                    var str = FormatMember(method);
-                    sw.WriteLine($"{GetIcon(method, str)}");
-                }
-                sw.WriteLine("</ul>");
-            }
-            if (type.GetMethods().Any())
-            {
-                sw.WriteLine($"<span class='memberGroup'>Methods</span><ul>");
-                foreach (var method in type.GetMethods())
-                {
-                    var str = FormatMember(method);
-                    sw.WriteLine($"{GetIcon(method, str)}");
-                }
-                sw.WriteLine("</ul>");
-            }
-            if (type.GetEvents().Any())
-            {
-                sw.WriteLine($"<span class='memberGroup'>Events</span><ul>");
-                foreach (var method in type.GetEvents())
-                {
-                    var str = FormatMember(method);
-                    sw.WriteLine($"{GetIcon(method, str)}");
-                }
-                sw.WriteLine("</ul>");
-            }
-            if (type.TypeKind == TypeKind.Enum)
-            {
-                sw.WriteLine("<ul>");
-                foreach (var e in type.GetEnums())
-                {
-                    string str = Briefify(e);
-                    sw.WriteLine($"{GetIcon(e, str)}");
-                }
-                sw.WriteLine("</ul>");
-            }
+
+            sw.Write(memberBuilder.ToString());
             sw.WriteLine("</div>");
             sw.Flush();
+        }
+
+        private bool IsTypeEmpty(INamedTypeSymbol type)
+        {
+            throw new NotImplementedException();
         }
 
         private string GetIcon(ISymbol type, string content)

--- a/src/Generator/Generators/HtmlOmdHeader.html
+++ b/src/Generator/Generators/HtmlOmdHeader.html
@@ -9,10 +9,11 @@
 		 ul { list-style:none; padding-left: 20px; margin-right:10px; }
          .objectBox { border-style:solid; border-width:1px; margin:10px; float:left; border-radius:10px;}
          .objectHeader { font-size:20px; }
-         .classHeaderBox { font-size:10px; background: linear-gradient(to right, rgb(211, 220, 239), white); padding:10px; border-radius:10px 10px; }
+         .classHeaderBox { font-size:10px; background: linear-gradient(to right, rgb(211, 220, 239), white); padding:10px; border-radius:10px 10px 0 0; }
          .structHeaderBox { font-size:10px; background: linear-gradient(to right, rgb(211, 220, 239), white); padding:10px; border-radius:10px 10px; }
-         .enumHeaderBox { font-size:10px; background: linear-gradient(to right, rgb(221, 214, 239), white); padding:10px; border-radius:10px 10px; }
-         .interfaceHeaderBox { font-size:10px; background: linear-gradient(to right, rgb(231, 240, 220), white); padding:10px; border-radius:10px 10px; }
+         .enumHeaderBox { font-size:10px; background: linear-gradient(to right, rgb(221, 214, 239), white); padding:10px; border-radius:10px 10px 0 0; }
+         .noMembers { border-radius: 10px; }
+         .interfaceHeaderBox { font-size:10px; background: linear-gradient(to right, rgb(231, 240, 220), white); padding:10px; border-radius:10px 10px 0 0; }
          .memberGroup { font-size:14px; background:rgb(240, 242, 239); display:block; padding:5px; }
          .namespaceHeader { font-size: 18px; background-color: black; padding:10px; color:white; clear:both; }
 


### PR DESCRIPTION
Items should have a squared bottom corners when they have members and rounded when there are no members

![image](https://user-images.githubusercontent.com/1594689/37679295-1ce68746-2c46-11e8-97b7-29a51cf8a802.png)

![image](https://user-images.githubusercontent.com/1594689/37679304-22983072-2c46-11e8-9a24-94c04497be17.png)
