### PR TITLE
Upgrade to DotNet Core 3.0

### DIFF
--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>generateomd</ToolCommandName>
     <PackageOutputPath>./../nupkg</PackageOutputPath>
     <PackageId>dotMorten.OmdGenerator</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <Authors>Morten Nielsen</Authors>
     <Product>OMD Generator</Product>
     <Description>Automatically generates an HTML Document with an object model diagram for your C# library&lt;</Description>


### PR DESCRIPTION
DotNet Core 3.0 is a major release, requiring many projects to upgrade.
This project currently fails on project running on dotnet core 3.0. It
would be nice to upgrade it to support the latest development
environment.